### PR TITLE
modify if statement for R 4.2.0

### DIFF
--- a/alra.R
+++ b/alra.R
@@ -109,7 +109,7 @@ alra <- function( A_norm, k=0,q=10, quantile.prob = 0.001, use.mkl = F, mkl.seed
     #     A_norm_rank15_cor <- result.completed[[3]] # The actual adjusted, completed matrix
 
     cat(sprintf("Read matrix with %d cells and %d genes\n", nrow(A_norm), ncol(A_norm)))
-    if (class(A_norm) != 'matrix') {
+    if (!(any(grepl("matrix", class(A_norm), ignore.case = TRUE)))) { 
         stop(sprintf("A_norm is of class %s, but it should be of class matrix. Did you forget to run as.matrix()?",class(A_norm)))
     }
 


### PR DESCRIPTION
Related to #18

From the R 4.0.0,
```
CHANGES IN R 4.0.0
SIGNIFICANT USER-VISIBLE CHANGES:
• matrix objects now also inherit from class "array", so e.g., class(diag(1))
is c("matrix","array"). This invalidates code incorrectly assuming that
class(matrix_obj)) has length one.
S3 methods for class "array" are now dispatched for matrix objects.
```

The class function will return not only 'matrix' but 'array'
So if comparing as 1d like `if (class(A_norm) != 'matrix')` does not work.
Here, I tried to implement if the class(A_norm) contains a matrix, return true.

### Checklist 
- [x] Work correctly
